### PR TITLE
Stepvideo-fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - opencv
   - tk
   - tqdm
+  - scipy
   - pip
   - pip:
     - tensorflow==2.7.0

--- a/faceblurring/faceblurer.py
+++ b/faceblurring/faceblurer.py
@@ -231,3 +231,10 @@ def tidy_up(vid_files, output_dir):
             print("Could not remove blurred timelapse video (it might still be open?)")
             input("Press enter to retry")
 
+
+def is_tlc_video(frame):
+    return (
+        (np.all(frame[1056, 50] == [16, 16, 16]))  # Bottom left corner
+        and (np.all(frame[1056, 1870] == [16, 16, 16]))  # Bottom right corner
+        and (np.all(frame[1056, 777] == [240, 240, 240]))  # "T" in TLC
+    )

--- a/faceblurring/settings.py
+++ b/faceblurring/settings.py
@@ -5,3 +5,5 @@ IMG_DIMS = 416  # Must be multiple of 32
 DEBUG = False
 OUTPUT_DIR = "C:/Users/mb/Desktop/KidVision Data"
 OUT_VID_FPS = 15.0
+STEP_VID_LENGTH = 3
+STEP_VID_INTERVAL = 0.5

--- a/faceblurring/utils.py
+++ b/faceblurring/utils.py
@@ -248,3 +248,10 @@ def _softmax(x, axis=-1):
     e_x = np.exp(x)
 
     return e_x / e_x.sum(axis, keepdims=True)
+
+
+def gen_step_frames(vid_fps, step_vid_length):
+    t = 0
+    while True:
+        yield int(t * vid_fps)
+        t += step_vid_length


### PR DESCRIPTION
Adds a set of functions to detect when the TLC has accidentally created a step video, and then selects the frames that most closely align with our protocol.
Closes #9